### PR TITLE
ci(semantic-release): add build step to release job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ jobs:
     steps:
       - checkout
       - run: npm install
+      - run: npm run build
       - run: npm run semantic-release
 
 workflows:


### PR DESCRIPTION
## PR Checklist

<!-- Please check out our Contribution Guide and our Code of Conduct for complete instructions. -->

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [our conventions](../CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[X] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Semantic release job is failing because it is configured to read `dist` so running `build` script is pre-requisite.

## What is the new behavior?
`build` script runs before `semantic-release` script.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```
